### PR TITLE
Fix generate hash method

### DIFF
--- a/lib/gravatar.dart
+++ b/lib/gravatar.dart
@@ -56,6 +56,6 @@ class Gravatar {
    */
 String _generateHash(String email) {
   String preparedEmail = (email.trim()).toLowerCase();
-  List digest = (new MD5()..add(preparedEmail.codeUnits)).close();
-  return CryptoUtils.bytesToHex(digest);
+  Digest digest = (md5.convert(preparedEmail.codeUnits));
+  return digest.toString();
 }


### PR DESCRIPTION
The method was broken due to changes in the latest version of the Crypto library. Have updated the method to resolve issue.